### PR TITLE
make wrapper source value publicly accessible

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ use futures_io::{AsyncRead, AsyncSeek, AsyncWrite};
 /// - `impl<T> AsyncRead for Arc<T> where &T: AsyncRead {}`
 /// - `impl<T> AsyncWrite for Arc<T> where &T: AsyncWrite {}`
 /// - `impl<T> AsyncSeek for Arc<T> where &T: AsyncSeek {}`
-pub struct Arc<T>(std::sync::Arc<T>);
+pub struct Arc<T>(pub std::sync::Arc<T>);
 
 impl<T> Unpin for Arc<T> {}
 


### PR DESCRIPTION
make wrapper source value publicly accessible so we can use associated non-method functions for Arc such as `std::sync::get_mut(this: &mut std::sync::Arc<T>)`