### PR TITLE
v1.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 1.2.4
+
+- Use the `async-lock` crate as the locking mechanism. (#14)
+
 # Version 1.2.3
 
 - Remove the unnecessary `simple-mutex` dependency. (#10)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-dup"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v1.x.y" git tag
-version = "1.2.3"
+version = "1.2.4"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.59"


### PR DESCRIPTION

- Use the `async-lock` crate as the locking mechanism. (#14)
- Set MSRV to 1.59. (#14)
